### PR TITLE
Potential fix for code scanning alert no. 1: Open URL redirect

### DIFF
--- a/internal/api/login.go
+++ b/internal/api/login.go
@@ -5,6 +5,8 @@ import (
 	"html/template"
 	"net/http"
 	"os"
+	"strings"
+	"net/url"
 	"time"
 )
 
@@ -47,7 +49,10 @@ func (s *Server) loginHandler(w http.ResponseWriter, r *http.Request) {
 
 	// ✅ safe redirect
 	next := r.FormValue("next")
-	if next == "" {
+	// sanitize and validate 'next'
+	next = strings.ReplaceAll(next, "\\", "/")
+	u, err := url.Parse(next)
+	if next == "" || err != nil || u.Hostname() != "" || !strings.HasPrefix(u.Path, "/") {
 		next = "/admin"
 	}
 	http.Redirect(w, r, next, http.StatusSeeOther)

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sync"
 	"time"
 
@@ -154,6 +155,12 @@ func (fs *FileStorage) UpdateBinary(binary *models.Binary) error {
 func (fs *FileStorage) DeleteBinary(id string) error {
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
+
+	// Validate id is a proper UUID (as expected by creation logic)
+	var validUUID = regexp.MustCompile(`^[a-fA-F0-9\-]{36}$`)
+	if !validUUID.MatchString(id) {
+		return errors.New("invalid binary id")
+	}
 
 	if _, exists := fs.binaries[id]; !exists {
 		return ErrBinaryNotFound

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -14,9 +15,21 @@ import (
 )
 
 var (
-	ErrBinaryNotFound = errors.New("binary not found")
-	ErrStorageInit    = errors.New("storage initialization failed")
+	ErrBinaryNotFound  = errors.New("binary not found")
+	ErrStorageInit     = errors.New("storage initialization failed")
+	ErrInvalidID       = errors.New("invalid ID supplied")
 )
+
+// isValidID checks that the id does not contain path separators or directory traversal
+func isValidID(id string) bool {
+	if len(id) == 0 ||
+		strings.Contains(id, "/") ||
+		strings.Contains(id, "\\") ||
+		strings.Contains(id, "..") {
+		return false
+	}
+	return true
+}
 
 // Storage interface for binary management
 type Storage interface {
@@ -150,6 +163,9 @@ func (fs *FileStorage) UpdateBinary(binary *models.Binary) error {
 	return fs.saveMetadata()
 }
 
+	if !isValidID(id) {
+		return ErrInvalidID
+	}
 // DeleteBinary deletes a binary
 func (fs *FileStorage) DeleteBinary(id string) error {
 	fs.mu.Lock()
@@ -168,6 +184,9 @@ func (fs *FileStorage) DeleteBinary(id string) error {
 	return fs.saveMetadata()
 }
 
+	if !isValidID(result.ID) {
+		return ErrInvalidID
+	}
 // SaveExecution saves an execution result
 func (fs *FileStorage) SaveExecution(result *models.ExecutionResult) error {
 	fs.mu.Lock()
@@ -185,6 +204,9 @@ func (fs *FileStorage) SaveExecution(result *models.ExecutionResult) error {
 	return os.WriteFile(execPath, data, 0644)
 }
 
+	if !isValidID(id) {
+		return nil, ErrInvalidID
+	}
 // GetExecution retrieves an execution result
 func (fs *FileStorage) GetExecution(id string) (*models.ExecutionResult, error) {
 	fs.mu.RLock()


### PR DESCRIPTION
Potential fix for [https://github.com/About80Ninjas/go_runner/security/code-scanning/1](https://github.com/About80Ninjas/go_runner/security/code-scanning/1)

To fix this problem, we should validate the `next` parameter to ensure the redirection URL is safe. Specifically, we should ensure that the value is either a relative URL (no host part), or best, only allow a set of permitted redirect paths (such as `/admin` or other internal locations)—this is most secure. At minimum, we can parse the input using `net/url`, replace all backslashes with slashes (to handle browser quirks), and ensure the parsed URL does not specify a host, making sure it's a local path. If the `next` value is either empty or not a safe relative path, we will default to `/admin`. This logic should be implemented in the `loginHandler`, just before the redirect. We can do this with standard library imports only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
