### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -14,9 +15,21 @@ import (
 )
 
 var (
-	ErrBinaryNotFound = errors.New("binary not found")
-	ErrStorageInit    = errors.New("storage initialization failed")
+	ErrBinaryNotFound  = errors.New("binary not found")
+	ErrStorageInit     = errors.New("storage initialization failed")
+	ErrInvalidID       = errors.New("invalid ID supplied")
 )
+
+// isValidID checks that the id does not contain path separators or directory traversal
+func isValidID(id string) bool {
+	if len(id) == 0 ||
+		strings.Contains(id, "/") ||
+		strings.Contains(id, "\\") ||
+		strings.Contains(id, "..") {
+		return false
+	}
+	return true
+}
 
 // Storage interface for binary management
 type Storage interface {
@@ -150,6 +163,9 @@ func (fs *FileStorage) UpdateBinary(binary *models.Binary) error {
 	return fs.saveMetadata()
 }
 
+	if !isValidID(id) {
+		return ErrInvalidID
+	}
 // DeleteBinary deletes a binary
 func (fs *FileStorage) DeleteBinary(id string) error {
 	fs.mu.Lock()
@@ -168,6 +184,9 @@ func (fs *FileStorage) DeleteBinary(id string) error {
 	return fs.saveMetadata()
 }
 
+	if !isValidID(result.ID) {
+		return ErrInvalidID
+	}
 // SaveExecution saves an execution result
 func (fs *FileStorage) SaveExecution(result *models.ExecutionResult) error {
 	fs.mu.Lock()
@@ -185,6 +204,9 @@ func (fs *FileStorage) SaveExecution(result *models.ExecutionResult) error {
 	return os.WriteFile(execPath, data, 0644)
 }
 
+	if !isValidID(id) {
+		return nil, ErrInvalidID
+	}
 // GetExecution retrieves an execution result
 func (fs *FileStorage) GetExecution(id string) (*models.ExecutionResult, error) {
 	fs.mu.RLock()


### PR DESCRIPTION
Potential fix for [https://github.com/About80Ninjas/go_runner/security/code-scanning/3](https://github.com/About80Ninjas/go_runner/security/code-scanning/3)

**General Approach:**  
Always validate and sanitize user input before using it to construct file paths. There are two safe and recommended strategies:
1. If only a flat namespace of IDs is expected (i.e., only a filename component, not a path), ensure the `id` does not contain path separators ("/" or "\\") or parent directory traversals ("..").
2. If wider paths are expected, ensure the resolved absolute file path is still under the expected (safe) directory, e.g. by checking the prefix after path resolution.

**Specific Fix for this Codebase:**  
Since `id` is used as an identifier, it is likely meant to be a "flat" filename component (e.g., a UUID string), so the most straightforward, robust fix is to:
- Check that the incoming `id` contains no path separators (`/`, `\`) or parent traversal strings (`..`) before using it in a file path in both `GetExecution`, `SaveExecution`, and any other method that uses directly-supplied ids as file components (such as `DeleteBinary`).
- If the input fails this check, respond with an error and do nothing.

**Implementation Steps:**  
- Add a validation helper function, e.g., `isValidID` that returns `false` if the string contains any forbidden character or substring.
- Call this validation function at the start of methods where untrusted IDs are used for file operations (`GetExecution`, `SaveExecution`, `DeleteBinary`).
- Return an error if the ID does not pass validation.

**Required Changes:**  
- Code changes only in `internal/storage/storage.go` to add the validation logic, update the relevant methods to check IDs, and (optionally) introduce a standard error to represent bad IDs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
