### PR TITLE
Potential fix for code scanning alert no. 1: Open URL redirect

### DIFF
--- a/internal/api/login.go
+++ b/internal/api/login.go
@@ -49,10 +49,13 @@ func (s *Server) loginHandler(w http.ResponseWriter, r *http.Request) {
 
 	// ✅ safe redirect
 	next := r.FormValue("next")
-	// sanitize and validate 'next'
+	// Define list of allowed redirect paths
+	allowedNext := map[string]struct{}{
+		"/admin": {},
+		"/dashboard": {},
+	}
 	next = strings.ReplaceAll(next, "\\", "/")
-	u, err := url.Parse(next)
-	if next == "" || err != nil || u.Hostname() != "" || !strings.HasPrefix(u.Path, "/") {
+	if _, ok := allowedNext[next]; !ok {
 		next = "/admin"
 	}
 	http.Redirect(w, r, next, http.StatusSeeOther)


### PR DESCRIPTION
Potential fix for [https://github.com/About80Ninjas/go_runner/security/code-scanning/1](https://github.com/About80Ninjas/go_runner/security/code-scanning/1)

The best fix is to replace the current ad-hoc validation (parsing and Hostname/path checks) with a safer approach: a whitelist of known-safe local redirect paths. If user input matches a safe value (typically from a fixed list of allowed redirects), use it, otherwise fall back to a hardcoded route (e.g., `/admin`). This eliminates edge-case parsing vulnerabilities. 

To implement this:

- In `loginHandler` (lines 50-59), replace the validation on `next` with a whitelist check.  
- Define a set of allowed paths (e.g., `"/admin"`, `"/dashboard"`, etc.) at the top or nearby for maintainability.
- If `next` matches one of these exactly, use it. Otherwise, default to `/admin`.
- Optionally, preserve or improve the backslash-replacement step for extra browser compatibility.

No new imports are needed; just standard Go features (slice, strings). Changes are isolated to `internal/api/login.go` in the `loginHandler` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
