### PR TITLE
Potential fix for code scanning alert no. 1: Open URL redirect

### DIFF
--- a/internal/api/login.go
+++ b/internal/api/login.go
@@ -4,6 +4,7 @@ package api
 import (
 	"html/template"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -54,8 +55,15 @@ func (s *Server) loginHandler(w http.ResponseWriter, r *http.Request) {
 		"/dashboard": {},
 	}
 	next = strings.ReplaceAll(next, "\\", "/")
-	if _, ok := allowedNext[next]; !ok {
+	u, err := url.Parse(next)
+	if err != nil || u.Hostname() != "" || u.Path == "" {
+		// fallback if next is malformed or external
 		next = "/admin"
+	} else if _, ok := allowedNext[u.Path]; !ok {
+		next = "/admin"
+	} else {
+		// use normalized and path-only form
+		next = u.Path
 	}
 	http.Redirect(w, r, next, http.StatusSeeOther)
 }


### PR DESCRIPTION
Potential fix for [https://github.com/About80Ninjas/go_runner/security/code-scanning/1](https://github.com/About80Ninjas/go_runner/security/code-scanning/1)

To ensure the redirection cannot be abused to leak users to external domains, we should parse the "`next`" value as a URL and check that its hostname is empty—meaning it’s a relative, local URL (per the best practices described above). We should perform this check **in addition** to validating `next` against the allowed paths, so only valid, local, and specifically whitelisted destinations can be used for redirection. This is implemented inside the `loginHandler` function in `internal/api/login.go`. 

The changes should:
- Normalize the "`next`" string (`\` → `/`).
- Parse as a URL.
- Ensure `u.Hostname()` is empty—if not, fall back to the safe default destination.
- Only redirect if the normalized, parsed, and validated input matches an allowed path.
- If any step fails (parsing, hostname, allowed list), redirect to `"/admin"`.

We will need to:
- Import `"net/url"` (standard library only).
- Update block in `loginHandler` accordingly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
